### PR TITLE
Fix release workflow trigger for non-v tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+      - '*'
 
 permissions:
   contents: write


### PR DESCRIPTION
Update the release workflow to trigger on any git tag. The previous configuration restricted it to tags starting with 'v', which caused the action to not run for the current tagging convention.

---
*PR created automatically by Jules for task [4172729041108218011](https://jules.google.com/task/4172729041108218011) started by @qrxnz*