### PR TITLE
Update vendorHash in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
           pname = "gopuntes";
           version = "1.0.5";
           src = self;
-          vendorHash = "sha256-tOBEcWX6JpqoPl7+H0L8RT+nnRRSNQ3FPrl95OwEEJo=";
+          vendorHash = "sha256-LkcZ/WwNHKC4fxf0OShE+x+qDmh2vYIJ1x8QQJKM44A=";
         };
       }
     );


### PR DESCRIPTION
Updated the `vendorHash` in `flake.nix` to resolve a hash mismatch error reported by Nix. Verified that the Go project still builds successfully.

---
*PR created automatically by Jules for task [5581368207907595906](https://jules.google.com/task/5581368207907595906) started by @qrxnz*